### PR TITLE
Create alert upon successful form requests

### DIFF
--- a/frontend-voucher/src/components/alert.tsx
+++ b/frontend-voucher/src/components/alert.tsx
@@ -1,0 +1,11 @@
+import Alert, { type AlertProps } from '@mui/material/Alert';
+
+type AlertComponentProps = AlertProps & {
+  text: string;
+};
+
+const AlertComponent = ({ text, ...props }: AlertComponentProps) => {
+  return <Alert {...props}>{text}</Alert>;
+};
+
+export default AlertComponent;

--- a/frontend-voucher/src/components/voucher-form/MemoVoucherForm.tsx
+++ b/frontend-voucher/src/components/voucher-form/MemoVoucherForm.tsx
@@ -1,6 +1,8 @@
 import { yupResolver } from '@hookform/resolvers/yup';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import ButtonGroup from '@mui/material/ButtonGroup';
 import Paper from '@mui/material/Paper';
+import clsx from 'clsx';
 import Lottie from 'lottie-react';
 import { memo, useEffect, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
@@ -10,6 +12,7 @@ import { actionLabels, categoryLabels } from '../../constants/form-labels';
 import voucherFormSchema from '../../constants/form-schema';
 import { voucherFormValues } from '../../constants/globalTypes';
 import { formatDate } from '../../utils/date';
+import AlertComponent from '../alert';
 import ButtonComponent from '../button';
 import DateSelector from '../form-inputs/date-picker';
 import RadioInputs from '../form-inputs/radio-inputs';
@@ -33,7 +36,7 @@ const VoucherFormComponent = ({ defaultValues }: VoucherFormProps) => {
     handleSubmit,
     reset,
     watch,
-    formState: { isDirty, isValid, isSubmitting, errors },
+    formState: { errors, isDirty, isSubmitting, isSubmitSuccessful, isValid },
   } = useForm<voucherFormValues>({
     defaultValues: defaultValues,
     mode: 'all',
@@ -73,6 +76,9 @@ const VoucherFormComponent = ({ defaultValues }: VoucherFormProps) => {
       }),
     };
     console.log(modifiedData);
+    // After showing alert for 4 seconds,
+    // user will be redirected to voucher page
+    // setTimeout(() => navigate('/vouchers'), 4000);
   };
 
   return (
@@ -81,11 +87,25 @@ const VoucherFormComponent = ({ defaultValues }: VoucherFormProps) => {
         elevation={3}
         className='mx-auto max-w-2xl rounded-lg py-4 lg:mx-0 xl:max-w-3xl'
       >
-        <div className='mb-4 border-0 border-b border-solid border-gray-700 pb-2'>
+        <div
+          className={clsx(
+            'mb-4 border-0 border-b border-solid border-gray-700 pb-2',
+            { 'mb-0': isSubmitSuccessful },
+          )}
+        >
           <h2 className='ml-3 font-mont text-2xl font-semibold tracking-wider text-gray-700 xl:text-3xl'>
             {watchAction} voucher
           </h2>
         </div>
+        {isSubmitSuccessful && (
+          <AlertComponent
+            className='mb-4 px-2'
+            iconMapping={{
+              success: <CheckCircleOutlineIcon fontSize='inherit' />,
+            }}
+            text={`The voucher has been successfully ${watchAction.toLowerCase()}d! You'll be redirected shortly.`}
+          />
+        )}
         <form onSubmit={handleSubmit(onSubmit)} className='px-3'>
           {watchAction !== 'Create' && (
             <RadioInputs


### PR DESCRIPTION
## What has changed.
1. Successful alert will be rendered on the form when the form request is successful.
  > There's no need to render error alert as form validation is handled properly before submission and API errors will be log on the console.

I believed this would  **_create a better UI experience_** for users instead of redirecting them to voucher data table after submission without any notification stating that the vouchers has been created/updated/deleted.

Once the alert is rendered, the user will be redirected to the voucher data table page after 4 seconds. This would be implemented with `setTimeOut(() => navigate('/vouchers), 4000)` in the future.

Examples:
- **Mobile**
<img width="349" alt="mobile_alert" src="https://user-images.githubusercontent.com/99808500/226160294-27ca3dbe-f719-4669-a26c-2bf9af2effc3.png">

- **Desktop**
<img width="782" alt="desktop_alert" src="https://user-images.githubusercontent.com/99808500/226160311-39cbcf8d-0cc7-439a-896f-34db4dc3c892.png">
