### PR TITLE
Fix typescript error for Vite

### DIFF
--- a/frontend-voucher/custom.d.ts
+++ b/frontend-voucher/custom.d.ts
@@ -1,4 +1,4 @@
-import 'vite/client';
+/// <reference types="vite/client" />
 
 declare module '*.svg' {
   import React = require('react');

--- a/frontend-voucher/src/hooks/useOutsideAlert.ts
+++ b/frontend-voucher/src/hooks/useOutsideAlert.ts
@@ -1,19 +1,28 @@
-import { Dispatch, RefObject, SetStateAction, useEffect } from 'react';
+import {
+  useEffect,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+} from 'react';
 
 function useOutsideAlerter(
   ref: RefObject<HTMLDivElement>,
   setState: Dispatch<SetStateAction<boolean>>,
 ) {
   useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
+    const handleClickOutside = (e: MouseEvent | TouchEvent) => {
       if (ref.current && !ref.current.contains(e.target as HTMLElement)) {
         setState(false);
       }
     };
 
-    document.addEventListener('click', handleClickOutside);
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
 
-    return () => document.removeEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
   }, [ref]);
 }
 

--- a/frontend-voucher/tsconfig.json
+++ b/frontend-voucher/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
   },
   "include": ["src", "custom.d.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
## What has changed?
- Fix Typescript error for vite on svg and env variables
- Add touchstart event listener for useOutsideContext hook, applicable if someone is using the app on touchscreen