### PR TITLE
Implement env for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+VITE_SHEET_DB_ID=<insert voucher sheet token here>
+VITE_SHEET_DB_TOKEN=<insert voucher sheet bearer token here>
+VITE_SHEET_ARCHIVE_ID=<insert archive sheet token here>
+VITE_SHEET_ARCHIVE_TOKEN=<insert archive sheet api bearer token here>

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,6 +24,18 @@ jobs:
       - name: Install project dependencies
         run: yarn install --immutable
 
+      - name: Write secrets to file
+        env:
+          archive_token: ${{ secrets.VITE_SHEET_ARCHIVE_TOKEN }}
+          archive_id: ${{ secrets.VITE_SHEET_ARCHIVE_ID }}
+          db_token: ${{ secrets.VITE_SHEET_DB_TOKEN }}
+          db_id: ${{ secrets.VITE_SHEET_DB_ID }}
+        run: |
+          echo "VITE_SHEET_ARCHIVE_TOKEN=${archive_token}" > .env.production
+          echo "VITE_SHEET_ARCHIVE_ID=${archive_id}" >> .env.production
+          echo "VITE_SHEET_DB_TOKEN=${db_token}" >> .env.production
+          echo "VITE_SHEET_DB_ID=${db_id}" >> .env.production
+
       - name: Build project
         run: yarn build
 


### PR DESCRIPTION
# Describe your changes
Create a `.env.production` file to store env variables
> Previously, I did not include env variables when migrating to Firebase hosting, hence the api to perform CRUD operation would not work.

Instead of relying on Firebase function to implement env variables, I used Vite build tool to set env variables in GitHub actions, it's secure since GitHub Actions hide the output of the secrets.

## Type of change
Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Recordings / Screenshots (if any)
